### PR TITLE
implemented truncating logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ All of them, except `FormatLogger`, just wrap existing loggers.
  - The `FileLogger` is a simple logger sink that writes to file.
  - The `DatetimeRotatingFileLogger` is a logger sink that writes to file, rotating logs based upon a user-provided `DateFormat`.
  - The `FormatLogger` is a logger sink that simply formats the message and writes to the logger stream.
- - The `TruncatingSimpleLogger` is a variant of `SimpleLogger` which truncates string representation of all variables it prints.
 
 By combining `TeeLogger` with filter loggers you can arbitrarily route log messages, wherever you want.
 

--- a/README.md
+++ b/README.md
@@ -341,29 +341,6 @@ Main | [Info] This is an informational message.
 Main | [Warn] This is a warning, should take a look.
 ```
 
-## `TruncatingSimpleLogger` (*Sink*)
-The `TruncatingSimpleLogger` is a sink that truncates the message and all variables string representations and prints to a wrapped IO.
-The max length which is not yet truncated is setup as a parameter of the constructor.
-
-```julia
-julia> using LoggingExtras
-
-julia> with_logger(TruncatingSimpleLogger(stdout, Logging.Info, 30)) do
-    short_var = "a"^5
-    long_var = "a"^50
-    @info "a short message" short_var long_var
-    @info "a very long message"^20 short_var long_var
-end
-┌ Info: a short message
-│   short_var = aaaaa
-│   long_var = aaaaaaaaaaaa…
-└ @ Main REPL[46]:4
-┌ Info: a very long messagea very lon…
-│   short_var = aaaaa
-│   long_var = aaaaaaaaaaaa…
-└ @ Main REPL[46]:5
-```
-
 # More Examples
 
 ## Filter out any overly long messages
@@ -434,4 +411,28 @@ This will produce output similar to:
 └ @ Base loading.jl:1240
 ┌ Error: 2019-09-20 17:43:54 ErrorException("SearchLight validation error(s) for Translations.Translation")
 └ @ TranslationsController ~/Dropbox/Projects/LiteCMS/app/resources/translations/TranslationsController.jl:69
+```
+
+## Truncate long variables and messages
+
+The `FormatLogger` is quite general and can be used e.g. to truncate long variables.
+There is `LoggingExtras.make_log_truncated(max_var_len=5_000)` function which formats data in similar manner as `ConsoleLogger`, but with truncation of string representation when it exceeds `max_var_len`.
+
+```julia
+julia> using LoggingExtras
+
+julia> with_logger(FormatLogger(LoggingExtras.make_log_truncated(30))) do
+    short_var = "a"^5
+    long_var = "a"^50
+    @info "a short message" short_var long_var
+    @info "a very long message"^20 short_var long_var
+end
+┌ Info: a short message
+│   short_var = aaaaa
+│   long_var = aaaaaaaaaaaa…
+└ @ Main REPL[46]:4
+┌ Info: a very long messagea very lon…
+│   short_var = aaaaa
+│   long_var = aaaaaaaaaaaa…
+└ @ Main REPL[46]:5
 ```

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ All of them, except `FormatLogger`, just wrap existing loggers.
  - The `FileLogger` is a simple logger sink that writes to file.
  - The `DatetimeRotatingFileLogger` is a logger sink that writes to file, rotating logs based upon a user-provided `DateFormat`.
  - The `FormatLogger` is a logger sink that simply formats the message and writes to the logger stream.
+ - The `TruncatingSimpleLogger` is a variant of `SimpleLogger` which truncates string representation of all variables it prints.
 
 By combining `TeeLogger` with filter loggers you can arbitrarily route log messages, wherever you want.
 
@@ -338,6 +339,22 @@ julia> with_logger(logger) do
        end
 Main | [Info] This is an informational message.
 Main | [Warn] This is a warning, should take a look.
+```
+
+## `TruncatingSimpleLogger` (*Sink*)
+The `TruncatingSimpleLogger` is a sink that truncates the message and all variables string representations and prints to a wrapped IO.
+The max length which is not yet truncated is setup as a parameter of the constructor.
+
+```julia
+julia> using LoggingExtras
+
+julia> with_logger(TruncatingSimpleLogger(stdout, Logging.Info, 30)) do
+           long_var = "a"^50
+           @info "a_message" long_var
+       end
+┌ Info: a_message
+│   long_var = aaaaaaaaaaaa…
+└ @ Main REPL[43]:3
 ```
 
 # More Examples

--- a/README.md
+++ b/README.md
@@ -349,12 +349,19 @@ The max length which is not yet truncated is setup as a parameter of the constru
 julia> using LoggingExtras
 
 julia> with_logger(TruncatingSimpleLogger(stdout, Logging.Info, 30)) do
-           long_var = "a"^50
-           @info "a_message" long_var
-       end
-┌ Info: a_message
+    short_var = "a"^5
+    long_var = "a"^50
+    @info "a short message" short_var long_var
+    @info "a very long message"^20 short_var long_var
+end
+┌ Info: a short message
+│   short_var = aaaaa
 │   long_var = aaaaaaaaaaaa…
-└ @ Main REPL[43]:3
+└ @ Main REPL[46]:4
+┌ Info: a very long messagea very lon…
+│   short_var = aaaaa
+│   long_var = aaaaaaaaaaaa…
+└ @ Main REPL[46]:5
 ```
 
 # More Examples

--- a/src/LoggingExtras.jl
+++ b/src/LoggingExtras.jl
@@ -10,7 +10,7 @@ import Base.CoreLogging:
 
 export TeeLogger, TransformerLogger, FileLogger,
     ActiveFilteredLogger, EarlyFilteredLogger, MinLevelLogger,
-    DatetimeRotatingFileLogger, FormatLogger
+    DatetimeRotatingFileLogger, FormatLogger, TruncatingSimpleLogger
 
 ######
 # Re export Logging.jl from stdlib 
@@ -50,6 +50,7 @@ include("minlevelfiltered.jl")
 include("filelogger.jl")
 include("formatlogger.jl")
 include("datetime_rotation.jl")
+include("truncating.jl")
 include("deprecated.jl")
 
 end # module

--- a/src/LoggingExtras.jl
+++ b/src/LoggingExtras.jl
@@ -10,7 +10,7 @@ import Base.CoreLogging:
 
 export TeeLogger, TransformerLogger, FileLogger,
     ActiveFilteredLogger, EarlyFilteredLogger, MinLevelLogger,
-    DatetimeRotatingFileLogger, FormatLogger, TruncatingSimpleLogger
+    DatetimeRotatingFileLogger, FormatLogger
 
 ######
 # Re export Logging.jl from stdlib 

--- a/src/truncating.jl
+++ b/src/truncating.jl
@@ -1,22 +1,6 @@
 # copied from https://github.com/JuliaLang/julia/blob/v1.5.4/stdlib/Logging/src/ConsoleLogger.jl
 using Logging
 import Logging: min_enabled_level, shouldlog, catch_exceptions, handle_message
-# todo: maybe try to push it to generic julia logging package
-struct TruncatingSimpleLogger <: AbstractLogger
-    stream::IO
-    min_level::LogLevel
-    message_limits::Dict{Any,Int}
-    max_var_len::Int
-end
-TruncatingSimpleLogger(stream::IO=stderr, level=Info, max_var_len=5_000) =
-    TruncatingSimpleLogger(stream, level, Dict{Any,Int}(), max_var_len)
-
-shouldlog(logger::TruncatingSimpleLogger, level, _module, group, id) =
-    get(logger.message_limits, id, 1) > 0
-
-min_enabled_level(logger::TruncatingSimpleLogger) = logger.min_level
-
-catch_exceptions(logger::TruncatingSimpleLogger) = false
 
 function shorten_str(message, max_len)
     suffix = "…"
@@ -27,28 +11,22 @@ function shorten_str(message, max_len)
     end
 end
 
-function handle_message(logger::TruncatingSimpleLogger, level, message, _module, group, id,
-                        filepath, line; maxlog=nothing, kwargs...)
-    if maxlog !== nothing && maxlog isa Integer
-        remaining = get!(logger.message_limits, id, maxlog)
-        logger.message_limits[id] = remaining - 1
-        remaining > 0 || return
+function make_log_truncated(max_var_len=5_000)
+    function log_truncated(io, args)
+        levelstr = args.level == Logging.Warn ? "Warning" : string(args.level)
+        msglines = split(chomp(string(shorten_str(args.message, max_var_len))), '\n')
+        println(io, "┌ ", levelstr, ": ", msglines[1])
+        for i in 2:length(msglines)
+            str_line = sprint(print, "│ ", msglines[i])
+            println(io, shorten_str(str_line, max_var_len))
+        end
+        for (key, val) in args.kwargs
+            str_line = sprint(print, "│   ", key, " = ", val)
+            println(io, shorten_str(str_line, max_var_len))
+        end
+        println(io, "└ @ ", something(args._module, "nothing"), " ",
+                something(args.file, "nothing"), ":", something(args.line, "nothing"))
+        nothing
     end
-    buf = IOBuffer()
-    iob = IOContext(buf, logger.stream)
-    levelstr = level == Logging.Warn ? "Warning" : string(level)
-    msglines = split(chomp(string(shorten_str(message, logger.max_var_len))), '\n')
-    println(iob, "┌ ", levelstr, ": ", msglines[1])
-    for i in 2:length(msglines)
-        str_line = sprint(print, "│ ", msglines[i])
-        println(iob, shorten_str(str_line, logger.max_var_len))
-    end
-    for (key, val) in kwargs
-        str_line = sprint(print, "│   ", key, " = ", val)
-        println(iob, shorten_str(str_line, logger.max_var_len))
-    end
-    println(iob, "└ @ ", something(_module, "nothing"), " ",
-            something(filepath, "nothing"), ":", something(line, "nothing"))
-    write(logger.stream, take!(buf))
-    nothing
+    log_truncated
 end

--- a/src/truncating.jl
+++ b/src/truncating.jl
@@ -1,0 +1,54 @@
+# copied from https://github.com/JuliaLang/julia/blob/v1.5.4/stdlib/Logging/src/ConsoleLogger.jl
+using Logging
+import Logging: min_enabled_level, shouldlog, catch_exceptions, handle_message
+# todo: maybe try to push it to generic julia logging package
+struct TruncatingSimpleLogger <: AbstractLogger
+    stream::IO
+    min_level::LogLevel
+    message_limits::Dict{Any,Int}
+    max_var_len::Int
+end
+TruncatingSimpleLogger(stream::IO=stderr, level=Info, max_var_len=5_000) =
+    TruncatingSimpleLogger(stream, level, Dict{Any,Int}(), max_var_len)
+
+shouldlog(logger::TruncatingSimpleLogger, level, _module, group, id) =
+    get(logger.message_limits, id, 1) > 0
+
+min_enabled_level(logger::TruncatingSimpleLogger) = logger.min_level
+
+catch_exceptions(logger::TruncatingSimpleLogger) = false
+
+function shorten_str(message, max_len)
+    suffix = "…"
+    if length(message) > max_len
+        message[1:min(end, max_len-length(suffix))] * suffix
+    else
+        message
+    end
+end
+
+function handle_message(logger::TruncatingSimpleLogger, level, message, _module, group, id,
+                        filepath, line; maxlog=nothing, kwargs...)
+    if maxlog !== nothing && maxlog isa Integer
+        remaining = get!(logger.message_limits, id, maxlog)
+        logger.message_limits[id] = remaining - 1
+        remaining > 0 || return
+    end
+    buf = IOBuffer()
+    iob = IOContext(buf, logger.stream)
+    levelstr = level == Logging.Warn ? "Warning" : string(level)
+    msglines = split(chomp(string(shorten_str(message, logger.max_var_len))), '\n')
+    println(iob, "┌ ", levelstr, ": ", msglines[1])
+    for i in 2:length(msglines)
+        str_line = sprint(print, "│ ", msglines[i])
+        println(iob, shorten_str(str_line, logger.max_var_len))
+    end
+    for (key, val) in kwargs
+        str_line = sprint(print, "│   ", key, " = ", val)
+        println(iob, shorten_str(str_line, logger.max_var_len))
+    end
+    println(iob, "└ @ ", something(_module, "nothing"), " ",
+            something(filepath, "nothing"), ":", something(line, "nothing"))
+    write(logger.stream, take!(buf))
+    nothing
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -246,8 +246,9 @@ end
 end
 
 @testset "Truncating" begin
+    trunc_fun = LoggingExtras.make_log_truncated(30)
     io = IOBuffer()
-    truncating_logger = TruncatingSimpleLogger(io, Logging.Info, 30)
+    truncating_logger = FormatLogger(trunc_fun, io)
     with_logger(truncating_logger) do
         @info "a"^50
     end
@@ -256,7 +257,7 @@ end
     @test occursin("Info: aaaaaaaaaaaaaaaaaaaaaaaaaaaaa…", str)
 
     io = IOBuffer()
-    truncating_logger = TruncatingSimpleLogger(io, Logging.Info, 30)
+    truncating_logger = FormatLogger(trunc_fun, io)
     with_logger(truncating_logger) do
         long_var = "a"^50
         @info "a_message" long_var
@@ -266,7 +267,7 @@ end
     @test occursin("│   long_var = aaaaaaaaaaaa…", str)
 
     io = IOBuffer()
-    truncating_logger = TruncatingSimpleLogger(io, Logging.Info, 30)
+    truncating_logger = FormatLogger(trunc_fun, io)
     with_logger(truncating_logger) do
         long_var = "a"^50
         short_var = "a"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -244,3 +244,36 @@ end
         @test Set(demux_logger.loggers) == Set([testlogger])
     end
 end
+
+@testset "Truncating" begin
+    io = IOBuffer()
+    truncating_logger = TruncatingSimpleLogger(io, Logging.Info, 30)
+    with_logger(truncating_logger) do
+        @info "a"^50
+    end
+    str = String(take!(io))
+
+    @test occursin("Info: aaaaaaaaaaaaaaaaaaaaaaaaaaaaa…", str)
+
+    io = IOBuffer()
+    truncating_logger = TruncatingSimpleLogger(io, Logging.Info, 30)
+    with_logger(truncating_logger) do
+        long_var = "a"^50
+        @info "a_message" long_var
+    end
+    str = String(take!(io))
+
+    @test occursin("│   long_var = aaaaaaaaaaaa…", str)
+
+    io = IOBuffer()
+    truncating_logger = TruncatingSimpleLogger(io, Logging.Info, 30)
+    with_logger(truncating_logger) do
+        long_var = "a"^50
+        short_var = "a"
+        @info "a_message" long_var short_var
+    end
+    str = String(take!(io))
+    
+    @test occursin("│   long_var = aaaaaaaaaaaa…", str)
+    @test occursin("│   short_var = a", str)
+end


### PR DESCRIPTION
Implemented truncating logger. 
Motivation for adding it was the fact that `FormatLogger` lets you format the message itself, but not variables themselves in a reasonable manner.