### PR TITLE
Release 1.0.0

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,7 @@
 The LoggingExtras.jl package is licensed under the MIT "Expat" License:
 
-> Copyright (c) 2018: Lyndon White <oxinabox@ucc.asn.au>
+> Copyright (c) 2022: Frames White <oxinabox@ucc.asn.au> and Collaborators
+> https://github.com/JuliaLogging/LoggingExtras.jl/graphs/contributors
 >
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LoggingExtras"
 uuid = "e6f89c97-d47a-5376-807f-9c37f3926c36"
-authors = ["Lyndon White <oxinabox@ucc.asn.au>"]
-version = "0.4.9"
+authors = ["Frames White <oxinabox@ucc.asn.au>", "Collaborators <https://github.com/JuliaLogging/LoggingExtras.jl/graphs/contributors>"]
+version = "1.0.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,5 +1,1 @@
-
-Base.@deprecate(
-    DemuxLogger(loggers::Vararg{AbstractLogger}; include_current_global=true),
-    include_current_global ? TeeLogger(global_logger(), loggers...) : TeeLogger(loggers...)
-)
+# There are currently no deprecations.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -293,23 +293,5 @@ end
 end
 
 @testset "Deprecations" begin
-    testlogger = TestLogger(min_level=BelowMinLevel)
-
-    @test_logs (:warn, r"deprecated") match_mode=:any begin
-        demux_logger = DemuxLogger(testlogger)
-        @test demux_logger isa TeeLogger
-        @test Set(demux_logger.loggers) == Set([testlogger, global_logger()])
-    end
-
-    @test_logs (:warn, r"deprecated") match_mode=:any begin
-        demux_logger = DemuxLogger(testlogger; include_current_global=true)
-        @test demux_logger isa TeeLogger
-        @test Set(demux_logger.loggers) == Set([testlogger, global_logger()])
-    end
-
-    @test_logs (:warn, r"deprecated") match_mode=:any begin
-        demux_logger = DemuxLogger(testlogger; include_current_global=false)
-        @test demux_logger isa TeeLogger
-        @test Set(demux_logger.loggers) == Set([testlogger])
-    end
+    # Nothing is currently deprecated
 end


### PR DESCRIPTION
This drops deprecations, and updates license etc.

In general, I don't register packages without going to 1.0.0 anymore.
SemVer is better at it's full power.