### PR TITLE
Switch verbosity macros to use group argument

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -272,6 +272,9 @@ end
             @debugv 0 "debug 0 message"
             @debugv 1 "debug 1 message"
             @debugv 2 "debug 2 message"
+            # error message *also* isn't logged since
+            # level *and* verbosity must match
+            @errorv 2 "error 2 message"
         end
     end
     @test length(logger.logs) == 2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -255,7 +255,8 @@ end
     with_logger(logger) do
         @infov 1 "info 1 message"
     end
-    @test isempty(logger.logs)
+    # if no verbosity filter is used, message is just like @info
+    @test !isempty(logger.logs)
 
     logger = TestLogger(min_level=Info)
     with_logger(logger) do
@@ -274,7 +275,8 @@ end
         end
     end
     @test length(logger.logs) == 2
-    @test map(x -> x.level, logger.logs) == [Debug, Debug-1]
+    @test logger.logs[1].group == LoggingExtras.Verbosity(0)
+    @test logger.logs[2].group == LoggingExtras.Verbosity(1)
 
     logger = TestLogger(min_level=Info)
     with_logger(logger) do


### PR DESCRIPTION
As noted in [this comment](https://github.com/JuliaLogging/LoggingExtras.jl/pull/64/files#r903295686), there's currently a semantic error with the verbosity macros where even if my verbosity is explicitly set to 0 or 1, but my log level is `Info`, then a message like:

```julia
@errorv 2 "more detailed error message than you normally want to see"
```

will still be logged, since the current logic just does `Error - 2`.

With the change proposed in this PR, we get the following change in behavior:
  * If `LoggingExtras.withlevel` or an alternative filter doesn't inspect the group.verbosity argument, then the verbose macros act just like the normal logging macros
  * If `withlevel` _is_ used, then the above case acts as expected; i.e. the `@errorv 2 msg` case only logs if `withlevel(Info; verbosity=2)` is set.

I opted to wrap the verbosity level in a new `LoggingExtras.Verbosity` struct so that if the `group` argument is ever used for something else as an `Int`, it won't accidentally conflict with the verbosity filtering. We'll still clobber that argument if anyone else tries to use it, but it shouldn't affect cases where people _aren't_ using the verbosity macros.

Fixes https://github.com/JuliaWeb/HTTP.jl/issues/938.