### PR TITLE
Add missing `do` to `withlevel` README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ calls. For example:
 using LoggingExtras
 
 function complex_user_call(; verbose=0)
-    LoggingExtras.withlevel(Debug; verbosity=verbose)
+    LoggingExtras.withlevel(Debug; verbosity=verbose) do
         # execute complex function body
         @debugv 1 "a level 1 verbosity debug message"
         @debugv 2 "a more verbose level 2 debug message"

--- a/src/verbosity.jl
+++ b/src/verbosity.jl
@@ -24,7 +24,7 @@ to the core logging logic as a `LoggingExtras.Verbosity` object.
 Note these "verbose" logging messages will only be filtered if a filter logger is used.
 A `LoggingExtras.EarlyFilteredLogger`can be used to filter on the `group.verbosity` argument.
 For convenience, the
-[`LoggintExtras.withlevel(f, level; verbosity)`](@ref) function is provided to temporarily
+[`LoggingExtras.withlevel(f, level; verbosity)`](@ref) function is provided to temporarily
 wrap the current logger with a log level and verbosity to filter while `f` is executed.
 """
 


### PR DESCRIPTION
I happened across this for the second time now, so figured it was a good moment to update the example and I found a small typo while I was searching for `withlevel` as well.