### PR TITLE
Use custom_isless() to compare all timescales from the user

### DIFF
--- a/src/Sinks/datetime_rotation.jl
+++ b/src/Sinks/datetime_rotation.jl
@@ -126,7 +126,7 @@ function next_datetime_transition(fmt::DateFormat)
 
     tokens = filter(t -> isa(t, Dates.DatePart), collect(fmt.tokens))
     minimum_timescale = first(sort(map(t -> token_timescales[extract_token(t)], tokens), lt=custom_isless))
-    if minimum_timescale < Minute(1)
+    if custom_isless(minimum_timescale, Minute(1))
         throw(ArgumentError("rotating the logger with sub-minute resolution not supported"))
     end
     return ceil(now(), minimum_timescale)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -189,6 +189,11 @@ end
         l1 = DatetimeRotatingFileLogger(dir, dateformat"yyyy-mm-dd.\l\o\g")
         l2 = DatetimeRotatingFileLogger(identity, dir, dateformat"yyyy-mm-dd.\l\o\g")
         @test l.filename_pattern == l1.filename_pattern == l2.filename_pattern
+
+        # Test large resolutions, which have some weirdness related to ordering
+        # (see next_datetime_transition()). These should not throw.
+        DatetimeRotatingFileLogger(dir, raw"yyyy-mm.\l\o\g")
+        DatetimeRotatingFileLogger(dir, raw"yyyy.\l\o\g")
     end
 end
 


### PR DESCRIPTION
Some timescale types don't have `isless()` defined between them so `next_datetime_transition()` defined a `custom_isless()` helper to sort them. But it wasn't used when checking for a minimum timescale, causing an exception if the user-requested minimum timescale was a year or month.