### PR TITLE
Fixed typos in docstring

### DIFF
--- a/src/CompositionalLoggers/minlevelfiltered.jl
+++ b/src/CompositionalLoggers/minlevelfiltered.jl
@@ -1,10 +1,10 @@
 """
     MinLevelLogger(logger, min_enabled_level)
 
-Wraps `logger` in an filter that runs before the log message is created.
+Wraps `logger` in a filter that runs before the log message is created.
 In many ways this is just a specialised [`EarlyFilteredLogger`](@ref)
 that only checks the level.
-This filter only allowed messages on or above the `min_enabled_level` to pass.
+This filter only allows messages on or above the `min_enabled_level` to pass.
 """
 struct MinLevelLogger{T <: AbstractLogger, L} <: AbstractLogger
     logger::T


### PR DESCRIPTION
Fixed typos in docstring for `MinLevelLogger`